### PR TITLE
[WIP] Fix errors emitted by PDFKit.new(html, default_options)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "hash_validator"
 
 # PDF generation
 gem "pdfkit"
+gem 'wkhtmltopdf-binary'
 
 group :test do
   gem "minitest", require: "minitest/autorun"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     tilt (2.0.1)
+    wkhtmltopdf-binary (0.9.9.3)
 
 PLATFORMS
   ruby
@@ -40,6 +41,7 @@ DEPENDENCIES
   sinatra
   sinatra-contrib
   thin
+  wkhtmltopdf-binary
 
 BUNDLED WITH
    1.10.4


### PR DESCRIPTION
Fixes weird output in `Printer.generate_pdf`.
Quick fix is to pull in another gem for this, as discussed years ago in: https://github.com/pdfkit/pdfkit/issues/118.

The pdf generation still works, and test output is now clean.
